### PR TITLE
Tally refactoring

### DIFF
--- a/mcdc/type_.py
+++ b/mcdc/type_.py
@@ -49,7 +49,6 @@ cs_tally = None
 technique = None
 
 global_ = None
-tally = None
 
 
 # ==============================================================================
@@ -1584,17 +1583,6 @@ def make_type_global(input_deck):
             ("source_seed", uint64),
         ]
     )
-
-
-def make_type_tally(input_deck, tally_size):
-    global tally
-
-    if not input_deck.technique["uq"]:
-        width = 3
-    else:
-        width = 5
-
-    tally = into_dtype([("tally", float64, (width, tally_size))])
 
 
 # ==============================================================================


### PR DESCRIPTION
Refactoring tally to their dedicated numpy arrays.

The previous tally data layout is set up as the following:
```
     # Set tally data
     if not input_deck.technique["uq"]:
         tally = np.zeros((3, tally_size), dtype=type_.float64)
     else:
         tally = np.zeros((5, tally_size), dtype=type_.float64)
 
     # =========================================================================
     # Establish Data Type from Tally Info and Construct Tallies
     # =========================================================================
 
     type_.make_type_tally(input_deck, tally_size)
     data_arr = np.zeros(1, dtype=type_.tally)
```

Instead of being represented as a standard 1D Numpy array (the one defined per `tally =`, which is no longer used at all), tally data is now represented as a single-element structured array (the one defined as `data_arr`). If I remember correctly, we went on this path because of some mutability challenges in GPU mode.
Nevertheless, this new path calls back our past limitation that shows up when the tally is super large (`tally_size` is very large), raising the following error:
```
  File "/g/g92/variansyah1/MCDC/mcdc/type_.py", line 164, in into_dtype
    result = np.dtype(align(field_list), align=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid shape in fixed-type tuple: dtype size in bytes must fit into a C int.
```

Per discussion with @braxtoncuneo, this change is going to work. However, some work needs to be done before the GPU mode can run.

Note that this refactoring is required to run the larger problems, like high-fidelity C5G7 and SMR 4-phase problems.

Question: Should we merge it now and later make a separate PR for the GPU fix, or should we wait until the GPU fix is in?