### PR TITLE
Convert testing framework to use numpy testing for array comparisons

### DIFF
--- a/test/regression/run.py
+++ b/test/regression/run.py
@@ -1,4 +1,4 @@
-import h5py, os, sys, argparse, fnmatch 
+import h5py, os, sys, argparse, fnmatch
 import numpy as np
 from colorama import Fore, Style
 
@@ -173,7 +173,7 @@ for i, name in enumerate(names):
                     if ("uq_var" in result) and (args.target == "gpu"):
                         continue
                     # Passed?
-                    try: 
+                    try:
                         np.testing.assert_allclose(a, b)
                         print(
                             Fore.GREEN + "  {}: Passed".format(name) + Style.RESET_ALL
@@ -182,14 +182,8 @@ for i, name in enumerate(names):
                         all_pass = False
                         error_msgs[-1].append(
                             "Differences in %s"
-                            % (
-                                name
-                                + "/"
-                                + result
-                                + "\n"
-                                + "{}\n".format(error)
-                            )
-                        ) 
+                            % (name + "/" + result + "\n" + "{}\n".format(error))
+                        )
                         print(Fore.RED + "  {}: Failed".format(name) + Style.RESET_ALL)
 
         # Other quantities

--- a/test/regression/run.py
+++ b/test/regression/run.py
@@ -179,7 +179,6 @@ for i, name in enumerate(names):
                             Fore.GREEN + "  {}: Passed".format(name) + Style.RESET_ALL
                         )
                     except AssertionError as error:
-                        message = str(error)
                         all_pass = False
                         error_msgs[-1].append(
                             "Differences in %s"

--- a/test/regression/run.py
+++ b/test/regression/run.py
@@ -1,4 +1,4 @@
-import h5py, os, sys, argparse, fnmatch
+import h5py, os, sys, argparse, fnmatch 
 import numpy as np
 from colorama import Fore, Style
 
@@ -173,11 +173,13 @@ for i, name in enumerate(names):
                     if ("uq_var" in result) and (args.target == "gpu"):
                         continue
                     # Passed?
-                    if np.isclose(a, b).all():
+                    try: 
+                        np.testing.assert_allclose(a, b)
                         print(
                             Fore.GREEN + "  {}: Passed".format(name) + Style.RESET_ALL
                         )
-                    else:
+                    except AssertionError as error:
+                        message = str(error)
                         all_pass = False
                         error_msgs[-1].append(
                             "Differences in %s"
@@ -186,10 +188,9 @@ for i, name in enumerate(names):
                                 + "/"
                                 + result
                                 + "\n"
-                                + "{}\n".format(a - b)
-                                + "Max difference: {}".format(np.max(np.abs(a - b)))
+                                + "{}\n".format(error)
                             )
-                        )
+                        ) 
                         print(Fore.RED + "  {}: Failed".format(name) + Style.RESET_ALL)
 
         # Other quantities
@@ -201,12 +202,13 @@ for i, name in enumerate(names):
             b = answer[result_name][()]
 
             # Passed?
-            if np.isclose(a, b).all():
+            try:
+                np.testing.assert_allclose(a, b)
                 print(Fore.GREEN + "  {}: Passed".format(result_name) + Style.RESET_ALL)
-            else:
+            except AssertionError as error:
                 all_pass = False
                 error_msgs[-1].append(
-                    "Differences in {}\n{}".format(result_name, a - b)
+                    "Differences in {}\n{}".format(result_name, error)
                 )
                 print(Fore.RED + "  {}: Failed".format(result_name) + Style.RESET_ALL)
 
@@ -216,12 +218,11 @@ for i, name in enumerate(names):
             name = f"iqmc/tally/{score}/mean"
             a = np.squeeze(output[name][()])
             b = np.squeeze(answer[name][()])
-            if np.isnan(b).all():
-                continue
             # Passed?
-            if np.isclose(a, b).all():
+            try:
+                np.testing.assert_allclose(a, b)
                 print(Fore.GREEN + "  {}: Passed".format(score) + Style.RESET_ALL)
-            else:
+            except AssertionError as error:
                 all_pass = False
                 error_msgs[-1].append("Differences in {}\n{}".format(score, a - b))
                 print(Fore.RED + "  {}: Failed".format(score) + Style.RESET_ALL)

--- a/test/regression/run.py
+++ b/test/regression/run.py
@@ -2,6 +2,8 @@ import h5py, os, sys, argparse, fnmatch
 import numpy as np
 from colorama import Fore, Style
 
+RELATIVE_TOLERANCE = 1e-6
+
 # Option parser
 parser = argparse.ArgumentParser(description="MC/DC regression test")
 parser.add_argument("--mode", type=str, choices=["python", "numba"], default="python")
@@ -174,7 +176,7 @@ for i, name in enumerate(names):
                         continue
                     # Passed?
                     try:
-                        np.testing.assert_allclose(a, b)
+                        np.testing.assert_allclose(a, b, rtol=RELATIVE_TOLERANCE)
                         print(
                             Fore.GREEN + "  {}: Passed".format(name) + Style.RESET_ALL
                         )
@@ -196,7 +198,7 @@ for i, name in enumerate(names):
 
             # Passed?
             try:
-                np.testing.assert_allclose(a, b)
+                np.testing.assert_allclose(a, b, rtol=RELATIVE_TOLERANCE)
                 print(Fore.GREEN + "  {}: Passed".format(result_name) + Style.RESET_ALL)
             except AssertionError as error:
                 all_pass = False
@@ -213,7 +215,7 @@ for i, name in enumerate(names):
             b = np.squeeze(answer[name][()])
             # Passed?
             try:
-                np.testing.assert_allclose(a, b)
+                np.testing.assert_allclose(a, b, rtol=RELATIVE_TOLERANCE)
                 print(Fore.GREEN + "  {}: Passed".format(score) + Style.RESET_ALL)
             except AssertionError as error:
                 all_pass = False

--- a/test/unit/transport/distributions/test_evaporation.py
+++ b/test/unit/transport/distributions/test_evaporation.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 
@@ -26,4 +27,4 @@ def test_evaporation_sample(rng_sequence, rng_state):
     # Since T(E_in) = 1.0 here, the prefactor is omitted in the simplified form below.
     expected_E = -math.log((1.0 - g * xi1) * (1.0 - g * xi2))
 
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)

--- a/test/unit/transport/distributions/test_kalbach_mann.py
+++ b/test/unit/transport/distributions/test_kalbach_mann.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 
@@ -31,5 +32,5 @@ def test_kalbach_mann_sample(rng_sequence, rng_state):
     #   mu = ln(T + sqrt(T^2 + 1)) / A = 0
     expected_mu = 0.0
 
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
-    assert math.isclose(sampled_mu, expected_mu, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(sampled_mu, expected_mu, rtol=0.0, atol=1e-12)

--- a/test/unit/transport/distributions/test_level_scattering.py
+++ b/test/unit/transport/distributions/test_level_scattering.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 
@@ -12,4 +13,4 @@ def test_level_scattering_sample():
     level = {"C1": 1.0, "C2": 0.5}
     sampled_E = dist.sample_level_scattering(5.0, level)
     expected_E = 2.0
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)

--- a/test/unit/transport/distributions/test_maxwellian.py
+++ b/test/unit/transport/distributions/test_maxwellian.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 from mcdc.constant import PI
@@ -23,4 +24,4 @@ def test_maxwellian_sample(rng_sequence, rng_state):
     # with theta = (pi / 2) * xi3 and T(E_in) = 1 for this test table.
     expected_E = -(math.log(xi1) + math.log(xi2) * math.cos(0.5 * PI * xi3) ** 2)
 
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)

--- a/test/unit/transport/distributions/test_multi_table.py
+++ b/test/unit/transport/distributions/test_multi_table.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 
@@ -27,4 +28,4 @@ def test_multi_table_distribution_sample(rng_sequence, rng_state):
     #   E_out = E_1 + (E' - E_l,1) * (E_K - E_1) / (E_l,K - E_l,1)
     expected_E = 55.0 + (E_prime - 100.0) * (165.0 - 55.0) / (300.0 - 100.0)
 
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)

--- a/test/unit/transport/distributions/test_nbody_correlated.py
+++ b/test/unit/transport/distributions/test_nbody_correlated.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 from mcdc.constant import DISTRIBUTION_N_BODY
@@ -33,5 +34,5 @@ def test_nbody_sample_correlated(rng_sequence, rng_state):
     expected_E = 2.0 + (0.2 - 0.0) * (4.0 - 2.0) / (0.4 - 0.0)
     expected_mu = 2.0 * 0.75 - 1.0
 
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
-    assert math.isclose(sampled_mu, expected_mu, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(sampled_mu, expected_mu, rtol=0.0, atol=1e-12)

--- a/test/unit/transport/distributions/test_tabulated_distribution.py
+++ b/test/unit/transport/distributions/test_tabulated_distribution.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 
@@ -16,4 +17,4 @@ def test_tabulated_distribution_sample(rng_sequence, rng_state):
     # (c_0, E_0) = (0.0, 1.0) and (c_1, E_1) = (0.4, 3.0) gives the expected value.
     expected_E = 1.0 + (0.2 - 0.0) * (3.0 - 1.0) / (0.4 - 0.0)
 
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)

--- a/test/unit/transport/distributions/test_tabulated_energy_angle.py
+++ b/test/unit/transport/distributions/test_tabulated_energy_angle.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 import mcdc.transport.distribution as dist
 
@@ -34,5 +35,5 @@ def test_tabulated_energy_angle_sample(rng_sequence, rng_state):
     # used. Sampling that table gives mu = -1 + xi_3 / 0.5.
     expected_mu = -1.0 + (xi3 - 0.0) / 0.5
 
-    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
-    assert math.isclose(sampled_mu, expected_mu, rel_tol=0.0, abs_tol=1e-12)
+    np.testing.assert_allclose(sampled_E, expected_E, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(sampled_mu, expected_mu, rtol=0.0, atol=1e-12)


### PR DESCRIPTION
## Summary of changes
<!--
    In at least one sentence, describe the PR you are submitting.
-->
This PR converts all array comparisons from using `assert np.isclose(a, b)` (or `math.isclose`) to use the built in testing helpers from `numpy.testing`, per @tylerjereddy's recommendation in #408. This change produces more specific error output on failed array comparisons.  

## Types of changes
<!---
    What types of changes does your code introduce?
-->

- Bug fix (non-breaking change which fixes an issue)

## Developer Checklist
<!---
    Please review the following checklist, and ensure you have addressed each item. Put an `x` in all boxes once completed.
-->

- [x] I have read the [contributing guide](https://mcdc.readthedocs.io/en/latest/contribution/index.html).
- [x] My code follows the [code style](https://mcdc.readthedocs.io/en/latest/contribution/index.html#code-styling) of this project.

## Associated Issues and PRs
<!--
    Please note any issues or pull requests associated with this pull request using GitHub keywords. 
    Note that for multiple issue linking, a keyword must be included before each issue.
-->

- related to #408

## Associated Developers
<!--
    Please mention any developers who should be alerted of this PR.
-->

- Dev: @
