### PR TITLE
test: replace bare assert np.isclose with np.testing.assert_allclose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 ### Changed
 
-- Unit test upgrade from [@massimolarsen]
-  - Combined `object_` and `transport` unit test for more efficient fixture reuse
+- Unit test upgrades
+  - Combined `object_` and `transport` unit test for more efficient fixture reuse from [@massimolarsen]
+  - Replace bare assert np.isclose with proper np.testing.assert_allclose from [@steps-re]
 
 ### Deprecated
 
@@ -120,3 +121,4 @@ The pre-refactor implementation remains available in the `cement` branch as a re
 [@nglaser3]: https://github.com/nglaser3
 [@gunnarrl]: https://github.com/gunnarrl
 [@Talen-Ayers]: https://github.com/Talen-Ayers
+[@steps-re]: https://github.com/steps-re

--- a/test/unit/geometry/surface/test_plane_x.py
+++ b/test/unit/geometry/surface/test_plane_x.py
@@ -66,7 +66,7 @@ def test_evaluate():
     def run(x, answer):
         particle["x"] = x
         result = plane_x.evaluate(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive side
     run(x=13.0, answer=3.0)
@@ -78,7 +78,7 @@ def test_reflect():
     def run(ux, answer):
         particle["ux"] = ux
         plane_x.reflect(particle_container, static_surface)
-        assert np.isclose(particle["ux"], answer)
+        np.testing.assert_allclose(particle["ux"], answer, rtol=1e-5, atol=1e-8)
 
     # From positive direction
     run(ux=0.2, answer=-0.2)
@@ -90,7 +90,7 @@ def test_get_normal_component():
     def run(ux, answer):
         particle["ux"] = ux
         result = plane_x.get_normal_component(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive direction
     run(ux=0.4, answer=0.4)
@@ -105,7 +105,7 @@ def test_get_distance():
         particle["x"] = x
         particle["ux"] = ux
         result = plane_x.get_distance(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive side
     x = 12.0
@@ -153,7 +153,7 @@ def test_interface_reflect():
     def run(ux, answer):
         particle["ux"] = ux
         interface.reflect(particle_container, static_surface)
-        assert np.isclose(particle["ux"], answer)
+        np.testing.assert_allclose(particle["ux"], answer, rtol=1e-5, atol=1e-8)
 
     # From positive direction
     run(ux=0.2, answer=-0.2)
@@ -165,14 +165,14 @@ def test_interface_evaluate():
     def run_static(x, answer):
         particle["x"] = x
         result = interface.evaluate(particle_container, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, ux, t, answer):
         particle["x"] = x
         particle["ux"] = ux
         particle["t"] = t
         result = interface.evaluate(particle_container, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -235,7 +235,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, static_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(ux, t, speed, answer):
         particle["ux"] = ux
@@ -243,7 +243,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, moving_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -301,14 +301,14 @@ def test_interface_check_sense():
         particle["ux"] = ux
         speed = 2.0  # Arbitrary
         result = interface.check_sense(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, ux, t, speed, answer):
         particle["x"] = x
         particle["ux"] = ux
         particle["t"] = t
         result = interface.check_sense(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -427,14 +427,14 @@ def test_interface_get_distance():
         particle["ux"] = ux
         speed = 2.0  # Arbitrary
         result = interface.get_distance(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, ux, t, speed, answer):
         particle["x"] = x
         particle["ux"] = ux
         particle["t"] = t
         result = interface.get_distance(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static

--- a/test/unit/geometry/surface/test_plane_y.py
+++ b/test/unit/geometry/surface/test_plane_y.py
@@ -66,7 +66,7 @@ def test_evaluate():
     def run(y, answer):
         particle["y"] = y
         result = plane_y.evaluate(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive side
     run(y=13.0, answer=3.0)
@@ -78,7 +78,7 @@ def test_reflect():
     def run(uy, answer):
         particle["uy"] = uy
         plane_y.reflect(particle_container, static_surface)
-        assert np.isclose(particle["uy"], answer)
+        np.testing.assert_allclose(particle["uy"], answer, rtol=1e-5, atol=1e-8)
 
     # From positive direction
     run(uy=0.2, answer=-0.2)
@@ -90,7 +90,7 @@ def test_get_normal_component():
     def run(uy, answer):
         particle["uy"] = uy
         result = plane_y.get_normal_component(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive direction
     run(uy=0.4, answer=0.4)
@@ -105,7 +105,7 @@ def test_get_distance():
         particle["y"] = y
         particle["uy"] = uy
         result = plane_y.get_distance(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive side
     y = 12.0
@@ -153,7 +153,7 @@ def test_interface_reflect():
     def run(uy, answer):
         particle["uy"] = uy
         interface.reflect(particle_container, static_surface)
-        assert np.isclose(particle["uy"], answer)
+        np.testing.assert_allclose(particle["uy"], answer, rtol=1e-5, atol=1e-8)
 
     # From positive direction
     run(uy=0.2, answer=-0.2)
@@ -165,14 +165,14 @@ def test_interface_evaluate():
     def run_static(y, answer):
         particle["y"] = y
         result = interface.evaluate(particle_container, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(y, uy, t, answer):
         particle["y"] = y
         particle["uy"] = uy
         particle["t"] = t
         result = interface.evaluate(particle_container, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -235,7 +235,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, static_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(uy, t, speed, answer):
         particle["uy"] = uy
@@ -243,7 +243,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, moving_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -301,14 +301,14 @@ def test_interface_check_sense():
         particle["uy"] = uy
         speed = 2.0  # Arbitrary
         result = interface.check_sense(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(y, uy, t, speed, answer):
         particle["y"] = y
         particle["uy"] = uy
         particle["t"] = t
         result = interface.check_sense(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -427,14 +427,14 @@ def test_interface_get_distance():
         particle["uy"] = uy
         speed = 2.0  # Arbitrary
         result = interface.get_distance(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(y, uy, t, speed, answer):
         particle["y"] = y
         particle["uy"] = uy
         particle["t"] = t
         result = interface.get_distance(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static

--- a/test/unit/geometry/surface/test_plane_z.py
+++ b/test/unit/geometry/surface/test_plane_z.py
@@ -66,7 +66,7 @@ def test_evaluate():
     def run(z, answer):
         particle["z"] = z
         result = plane_z.evaluate(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive side
     run(z=13.0, answer=3.0)
@@ -78,7 +78,7 @@ def test_reflect():
     def run(uz, answer):
         particle["uz"] = uz
         plane_z.reflect(particle_container, static_surface)
-        assert np.isclose(particle["uz"], answer)
+        np.testing.assert_allclose(particle["uz"], answer, rtol=1e-5, atol=1e-8)
 
     # From positive direction
     run(uz=0.2, answer=-0.2)
@@ -90,7 +90,7 @@ def test_get_normal_component():
     def run(uz, answer):
         particle["uz"] = uz
         result = plane_z.get_normal_component(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive direction
     run(uz=0.4, answer=0.4)
@@ -105,7 +105,7 @@ def test_get_distance():
         particle["z"] = z
         particle["uz"] = uz
         result = plane_z.get_distance(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Positive side
     z = 12.0
@@ -153,7 +153,7 @@ def test_interface_reflect():
     def run(uz, answer):
         particle["uz"] = uz
         interface.reflect(particle_container, static_surface)
-        assert np.isclose(particle["uz"], answer)
+        np.testing.assert_allclose(particle["uz"], answer, rtol=1e-5, atol=1e-8)
 
     # From positive direction
     run(uz=0.2, answer=-0.2)
@@ -165,14 +165,14 @@ def test_interface_evaluate():
     def run_static(z, answer):
         particle["z"] = z
         result = interface.evaluate(particle_container, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(z, uz, t, answer):
         particle["z"] = z
         particle["uz"] = uz
         particle["t"] = t
         result = interface.evaluate(particle_container, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -235,7 +235,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, static_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(uz, t, speed, answer):
         particle["uz"] = uz
@@ -243,7 +243,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, moving_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -301,14 +301,14 @@ def test_interface_check_sense():
         particle["uz"] = uz
         speed = 2.0  # Arbitrary
         result = interface.check_sense(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(z, uz, t, speed, answer):
         particle["z"] = z
         particle["uz"] = uz
         particle["t"] = t
         result = interface.check_sense(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -427,14 +427,14 @@ def test_interface_get_distance():
         particle["uz"] = uz
         speed = 2.0  # Arbitrary
         result = interface.get_distance(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(z, uz, t, speed, answer):
         particle["z"] = z
         particle["uz"] = uz
         particle["t"] = t
         result = interface.get_distance(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static

--- a/test/unit/geometry/surface/test_torus.py
+++ b/test/unit/geometry/surface/test_torus.py
@@ -82,7 +82,9 @@ def test_evaluate_matches_torus_z():
         general_result = torus.evaluate(particle_container, axis_aligned_surface)
         reference_result = torus_z.evaluate(particle_container, reference_surface)
 
-        np.testing.assert_allclose(general_result, reference_result, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            general_result, reference_result, rtol=1e-5, atol=1e-8
+        )
 
     run(x=1.0, y=0.0, z=0.0)
     run(x=1.5, y=0.0, z=0.0)

--- a/test/unit/geometry/surface/test_torus.py
+++ b/test/unit/geometry/surface/test_torus.py
@@ -82,7 +82,7 @@ def test_evaluate_matches_torus_z():
         general_result = torus.evaluate(particle_container, axis_aligned_surface)
         reference_result = torus_z.evaluate(particle_container, reference_surface)
 
-        assert np.isclose(general_result, reference_result)
+        np.testing.assert_allclose(general_result, reference_result, rtol=1e-5, atol=1e-8)
 
     run(x=1.0, y=0.0, z=0.0)
     run(x=1.5, y=0.0, z=0.0)
@@ -97,7 +97,7 @@ def test_oblique_evaluate():
         particle["z"] = 0.0
 
         result = torus.evaluate(particle_container, oblique_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Inside
     run(x=R, answer=-0.9375)
@@ -119,7 +119,7 @@ def test_oblique_get_normal_component():
         particle["uz"] = 0.0
 
         result = torus.get_normal_component(particle_container, oblique_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # On the outer surface, the outward normal is +x
     run(x=R + r, ux=-1.0, answer=-1.0)
@@ -136,7 +136,7 @@ def test_oblique_get_distance():
         particle["uz"] = 0.0
 
         result = torus.get_distance(particle_container, oblique_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Outside, moving inward toward the outer surface
     run(x=R + 2.0 * r, ux=-1.0, answer=r)
@@ -156,7 +156,7 @@ def test_interface_evaluate_oblique():
     particle["z"] = 0.0
 
     result = interface.evaluate(particle_container, oblique_surface, data)
-    assert np.isclose(result, -0.9375)
+    np.testing.assert_allclose(result, -0.9375, rtol=1e-5, atol=1e-8)
 
 
 def test_interface_get_distance_oblique():
@@ -169,4 +169,4 @@ def test_interface_get_distance_oblique():
 
     speed = 1.0
     result = interface.get_distance(particle_container, speed, oblique_surface, data)
-    assert np.isclose(result, r)
+    np.testing.assert_allclose(result, r, rtol=1e-5, atol=1e-8)

--- a/test/unit/geometry/surface/test_torus_x.py
+++ b/test/unit/geometry/surface/test_torus_x.py
@@ -73,7 +73,7 @@ def test_evaluate():
         particle["z"] = z
         particle["x"] = x
         result = torus_x.evaluate(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Inside
     run(y=1.0, z=0.0, x=0.0, answer=-0.9375)
@@ -92,7 +92,7 @@ def test_reflect():
         particle["ux"] = ux
         torus_x.reflect(particle_container, static_surface)
         directions = np.array([particle["uy"], particle["uz"], particle["ux"]])
-        assert np.allclose(directions, answers)
+        np.testing.assert_allclose(directions, answers, rtol=1e-5, atol=1e-8)
 
     # Particle traveling in through the Top of the torus
     run(y=R, z=0.0, x=(r + TINY), uy=0.0, uz=0.0, ux=-1.0, answers=np.array([0, 0, 1]))
@@ -140,7 +140,7 @@ def test_get_normal_component():
         particle["uz"] = uz
         particle["ux"] = ux
         result = torus_x.get_normal_component(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Particle traveling in through the Top of the torus
     run(y=R, z=0.0, x=(r + TINY), uy=0.0, uz=0.0, ux=-1.0, answer=-1)
@@ -161,7 +161,7 @@ def test_get_distance():
         particle["uz"] = uz
         particle["ux"] = ux
         result = torus_x.get_distance(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Outside Torus
     y = R
@@ -219,7 +219,7 @@ def test_interface_reflect():
         particle["ux"] = ux
         interface.reflect(particle_container, static_surface)
         directions = np.array([particle["uy"], particle["uz"], particle["ux"]])
-        assert np.allclose(directions, answers)
+        np.testing.assert_allclose(directions, answers, rtol=1e-5, atol=1e-8)
 
     run(y=R, z=0.0, x=(r + TINY), uy=0.0, uz=0.0, ux=-1.0, answers=np.array([0, 0, 1]))
     run(y=R, z=0.0, x=(r - TINY), uy=0.0, uz=0.0, ux=1.0, answers=np.array([0, 0, -1]))
@@ -260,7 +260,7 @@ def test_interface_evaluate():
         particle["z"] = z
         particle["x"] = x
         result = interface.evaluate(particle_container, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(y, z, x, uy, uz, ux, t, answer):
         particle["y"] = y
@@ -271,7 +271,7 @@ def test_interface_evaluate():
         particle["ux"] = ux
         particle["t"] = t
         result = interface.evaluate(particle_container, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -349,7 +349,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, static_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(y, z, x, uy, uz, ux, t, speed, answer):
         particle["y"] = y
@@ -362,7 +362,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, moving_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -512,7 +512,7 @@ def test_interface_check_sense():  # Returns true if the particle is on the outs
         particle["ux"] = ux
         speed = 2.0  # Arbitrary
         result = interface.check_sense(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(y, z, x, uy, uz, ux, t, speed, answer):
         particle["y"] = y
@@ -523,7 +523,7 @@ def test_interface_check_sense():  # Returns true if the particle is on the outs
         particle["ux"] = ux
         particle["t"] = t
         result = interface.check_sense(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -679,7 +679,7 @@ def test_interface_get_distance():
         particle["ux"] = ux
         speed = 2.0  # Arbitrary
         result = interface.get_distance(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(y, z, x, uy, uz, ux, t, speed, answer):
         particle["y"] = y
@@ -690,7 +690,7 @@ def test_interface_get_distance():
         particle["ux"] = ux
         particle["t"] = t
         result = interface.get_distance(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static

--- a/test/unit/geometry/surface/test_torus_y.py
+++ b/test/unit/geometry/surface/test_torus_y.py
@@ -73,7 +73,7 @@ def test_evaluate():
         particle["z"] = z
         particle["y"] = y
         result = torus_y.evaluate(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Inside
     run(x=1.0, z=0.0, y=0.0, answer=-0.9375)
@@ -92,7 +92,7 @@ def test_reflect():
         particle["uy"] = uy
         torus_y.reflect(particle_container, static_surface)
         directions = np.array([particle["ux"], particle["uz"], particle["uy"]])
-        assert np.allclose(directions, answers)
+        np.testing.assert_allclose(directions, answers, rtol=1e-5, atol=1e-8)
 
     # Particle traveling in through the Top of the torus
     run(x=R, z=0.0, y=(r + TINY), ux=0.0, uz=0.0, uy=-1.0, answers=np.array([0, 0, 1]))
@@ -140,7 +140,7 @@ def test_get_normal_component():
         particle["uz"] = uz
         particle["uy"] = uy
         result = torus_y.get_normal_component(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Particle traveling in through the Top of the torus
     run(x=R, z=0.0, y=(r + TINY), ux=0.0, uz=0.0, uy=-1.0, answer=-1)
@@ -161,7 +161,7 @@ def test_get_distance():
         particle["uz"] = uz
         particle["uy"] = uy
         result = torus_y.get_distance(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Outside Torus
     x = R
@@ -219,7 +219,7 @@ def test_interface_reflect():
         particle["uy"] = uy
         interface.reflect(particle_container, static_surface)
         directions = np.array([particle["ux"], particle["uz"], particle["uy"]])
-        assert np.allclose(directions, answers)
+        np.testing.assert_allclose(directions, answers, rtol=1e-5, atol=1e-8)
 
     run(x=R, z=0.0, y=(r + TINY), ux=0.0, uz=0.0, uy=-1.0, answers=np.array([0, 0, 1]))
     run(x=R, z=0.0, y=(r - TINY), ux=0.0, uz=0.0, uy=1.0, answers=np.array([0, 0, -1]))
@@ -260,7 +260,7 @@ def test_interface_evaluate():
         particle["z"] = z
         particle["y"] = y
         result = interface.evaluate(particle_container, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, z, y, ux, uz, uy, t, answer):
         particle["x"] = x
@@ -271,7 +271,7 @@ def test_interface_evaluate():
         particle["uy"] = uy
         particle["t"] = t
         result = interface.evaluate(particle_container, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -349,7 +349,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, static_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, z, y, ux, uz, uy, t, speed, answer):
         particle["x"] = x
@@ -362,7 +362,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, moving_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -512,7 +512,7 @@ def test_interface_check_sense():  # Returns true if the particle is on the outs
         particle["uy"] = uy
         speed = 2.0  # Arbitrary
         result = interface.check_sense(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, z, y, ux, uz, uy, t, speed, answer):
         particle["x"] = x
@@ -523,7 +523,7 @@ def test_interface_check_sense():  # Returns true if the particle is on the outs
         particle["uy"] = uy
         particle["t"] = t
         result = interface.check_sense(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -679,7 +679,7 @@ def test_interface_get_distance():
         particle["uy"] = uy
         speed = 2.0  # Arbitrary
         result = interface.get_distance(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, z, y, ux, uz, uy, t, speed, answer):
         particle["x"] = x
@@ -690,7 +690,7 @@ def test_interface_get_distance():
         particle["uy"] = uy
         particle["t"] = t
         result = interface.get_distance(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static

--- a/test/unit/geometry/surface/test_torus_z.py
+++ b/test/unit/geometry/surface/test_torus_z.py
@@ -73,7 +73,7 @@ def test_evaluate():
         particle["y"] = y
         particle["z"] = z
         result = torus_z.evaluate(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Inside
     run(x=1.0, y=0.0, z=0.0, answer=-0.9375)
@@ -92,7 +92,7 @@ def test_reflect():
         particle["uz"] = uz
         torus_z.reflect(particle_container, static_surface)
         directions = np.array([particle["ux"], particle["uy"], particle["uz"]])
-        assert np.allclose(directions, answers)
+        np.testing.assert_allclose(directions, answers, rtol=1e-5, atol=1e-8)
 
     # Particle traveling in through the Top of the torus
     run(x=R, y=0.0, z=(r + TINY), ux=0.0, uy=0.0, uz=-1.0, answers=np.array([0, 0, 1]))
@@ -140,7 +140,7 @@ def test_get_normal_component():
         particle["uy"] = uy
         particle["uz"] = uz
         result = torus_z.get_normal_component(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Particle traveling in through the Top of the torus
     run(x=R, y=0.0, z=(r + TINY), ux=0.0, uy=0.0, uz=-1.0, answer=-1)
@@ -161,7 +161,7 @@ def test_get_distance():
         particle["uy"] = uy
         particle["uz"] = uz
         result = torus_z.get_distance(particle_container, static_surface)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # Outside Torus
     x = R
@@ -219,7 +219,7 @@ def test_interface_reflect():
         particle["uz"] = uz
         interface.reflect(particle_container, static_surface)
         directions = np.array([particle["ux"], particle["uy"], particle["uz"]])
-        assert np.allclose(directions, answers)
+        np.testing.assert_allclose(directions, answers, rtol=1e-5, atol=1e-8)
 
     run(x=R, y=0.0, z=(r + TINY), ux=0.0, uy=0.0, uz=-1.0, answers=np.array([0, 0, 1]))
     run(x=R, y=0.0, z=(r - TINY), ux=0.0, uy=0.0, uz=1.0, answers=np.array([0, 0, -1]))
@@ -260,7 +260,7 @@ def test_interface_evaluate():
         particle["y"] = y
         particle["z"] = z
         result = interface.evaluate(particle_container, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, y, z, ux, uy, uz, t, answer):
         particle["x"] = x
@@ -271,7 +271,7 @@ def test_interface_evaluate():
         particle["uz"] = uz
         particle["t"] = t
         result = interface.evaluate(particle_container, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -349,7 +349,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, static_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, y, z, ux, uy, uz, t, speed, answer):
         particle["x"] = x
@@ -362,7 +362,7 @@ def test_interface_get_normal_component():
         result = interface.get_normal_component(
             particle_container, speed, moving_surface, data
         )
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -512,7 +512,7 @@ def test_interface_check_sense():  # Returns true if the particle is on the outs
         particle["uz"] = uz
         speed = 2.0  # Arbitrary
         result = interface.check_sense(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, y, z, ux, uy, uz, t, speed, answer):
         particle["x"] = x
@@ -523,7 +523,7 @@ def test_interface_check_sense():  # Returns true if the particle is on the outs
         particle["uz"] = uz
         particle["t"] = t
         result = interface.check_sense(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static
@@ -679,7 +679,7 @@ def test_interface_get_distance():
         particle["uz"] = uz
         speed = 2.0  # Arbitrary
         result = interface.get_distance(particle_container, speed, static_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     def run_moving(x, y, z, ux, uy, uz, t, speed, answer):
         particle["x"] = x
@@ -690,7 +690,7 @@ def test_interface_get_distance():
         particle["uz"] = uz
         particle["t"] = t
         result = interface.get_distance(particle_container, speed, moving_surface, data)
-        assert np.isclose(result, answer)
+        np.testing.assert_allclose(result, answer, rtol=1e-5, atol=1e-8)
 
     # =================================================================================
     # Static

--- a/test/unit/tally/test_cell_filter_interior_plane.py
+++ b/test/unit/tally/test_cell_filter_interior_plane.py
@@ -32,9 +32,9 @@ def test_cell_filter_ignores_redundant_interior_surface_crossing(
     particle_container = crossing_particle(s3.ID, x=3.0, ux=0.5, cell_ID=c.ID)
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
 
 
 def _build_cube_with_interior_plane(material_mg):
@@ -89,9 +89,9 @@ def test_cell_filter_ignores_interior_plane_crossing(material_mg, crossing_parti
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
 
 
 def test_cell_filter_scores_real_face_entry(material_mg, crossing_particle):
@@ -113,6 +113,6 @@ def test_cell_filter_scores_real_face_entry(material_mg, crossing_particle):
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 0), -2.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 1), 2.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), -2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)

--- a/test/unit/tally/test_cell_filter_interior_plane.py
+++ b/test/unit/tally/test_cell_filter_interior_plane.py
@@ -32,9 +32,15 @@ def test_cell_filter_ignores_redundant_interior_surface_crossing(
     particle_container = crossing_particle(s3.ID, x=3.0, ux=0.5, cell_ID=c.ID)
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def _build_cube_with_interior_plane(material_mg):
@@ -89,9 +95,15 @@ def test_cell_filter_ignores_interior_plane_crossing(material_mg, crossing_parti
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_cell_filter_scores_real_face_entry(material_mg, crossing_particle):
@@ -113,6 +125,12 @@ def test_cell_filter_scores_real_face_entry(material_mg, crossing_particle):
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), -2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 0), -2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8
+    )

--- a/test/unit/tally/test_cell_tally.py
+++ b/test/unit/tally/test_cell_tally.py
@@ -32,7 +32,9 @@ def test_surface_cell_filter_current_net_is_incoming_negative_outgoing_positive(
         cell_ID=slab_plane_x["c_left"].ID,
     )
     surface_crossing(particle_container, mcdc_struct, data)
-    np.testing.assert_allclose(_bin_value(current_tally, mcdc_struct, data), -2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value(current_tally, mcdc_struct, data), -2.0, rtol=1e-5, atol=1e-8
+    )
 
     # Right -> left across the shared interior surface: outgoing from c_right (+)
     particle_container = crossing_particle(
@@ -42,7 +44,9 @@ def test_surface_cell_filter_current_net_is_incoming_negative_outgoing_positive(
         cell_ID=slab_plane_x["c_right"].ID,
     )
     surface_crossing(particle_container, mcdc_struct, data)
-    np.testing.assert_allclose(_bin_value(current_tally, mcdc_struct, data), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value(current_tally, mcdc_struct, data), 0.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_surface_cell_filter_current_records_in_and_out_separately(
@@ -74,9 +78,15 @@ def test_surface_cell_filter_current_records_in_and_out_separately(
 
     # Scores are in requested order: [current-net, current-in, current-out].
     # Partial currents are positive; current-net is incoming-negative/outgoing-positive.
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_surface_cell_filter_current_counts_outgoing_to_vacuum(
@@ -100,9 +110,15 @@ def test_surface_cell_filter_current_counts_outgoing_to_vacuum(
     particle = particle_container[0]
     surface_crossing(particle_container, mcdc_struct, data)
     assert not particle["alive"]
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 0), 2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_surface_cell_filter_current_ignores_reflective_crossing(
@@ -125,9 +141,15 @@ def test_surface_cell_filter_current_ignores_reflective_crossing(
     surface_crossing(particle_container, mcdc_struct, data)
     assert particle["alive"]
     np.testing.assert_allclose(particle["ux"], -0.5, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_surface_cell_filter_current_scores_curved_boundary(
@@ -154,9 +176,15 @@ def test_surface_cell_filter_current_scores_curved_boundary(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 0), 2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8
+    )
 
     # Outer -> inner across the same curved surface: incoming to c_inner (-)
     particle_container = crossing_particle(
@@ -167,9 +195,15 @@ def test_surface_cell_filter_current_scores_curved_boundary(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_surface_cell_filter_scores_only_selected_surface(
@@ -193,9 +227,15 @@ def test_surface_cell_filter_scores_only_selected_surface(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8
+    )
 
     particle_container = crossing_particle(
         slab_plane_x["s_mid"].ID,
@@ -205,6 +245,12 @@ def test_surface_cell_filter_scores_only_selected_surface(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), -2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 0), -2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        _bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8
+    )

--- a/test/unit/tally/test_cell_tally.py
+++ b/test/unit/tally/test_cell_tally.py
@@ -32,7 +32,7 @@ def test_surface_cell_filter_current_net_is_incoming_negative_outgoing_positive(
         cell_ID=slab_plane_x["c_left"].ID,
     )
     surface_crossing(particle_container, mcdc_struct, data)
-    assert np.isclose(_bin_value(current_tally, mcdc_struct, data), -2.0)
+    np.testing.assert_allclose(_bin_value(current_tally, mcdc_struct, data), -2.0, rtol=1e-5, atol=1e-8)
 
     # Right -> left across the shared interior surface: outgoing from c_right (+)
     particle_container = crossing_particle(
@@ -42,7 +42,7 @@ def test_surface_cell_filter_current_net_is_incoming_negative_outgoing_positive(
         cell_ID=slab_plane_x["c_right"].ID,
     )
     surface_crossing(particle_container, mcdc_struct, data)
-    assert np.isclose(_bin_value(current_tally, mcdc_struct, data), 0.0)
+    np.testing.assert_allclose(_bin_value(current_tally, mcdc_struct, data), 0.0, rtol=1e-5, atol=1e-8)
 
 
 def test_surface_cell_filter_current_records_in_and_out_separately(
@@ -74,9 +74,9 @@ def test_surface_cell_filter_current_records_in_and_out_separately(
 
     # Scores are in requested order: [current-net, current-in, current-out].
     # Partial currents are positive; current-net is incoming-negative/outgoing-positive.
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 2.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
 
 
 def test_surface_cell_filter_current_counts_outgoing_to_vacuum(
@@ -100,9 +100,9 @@ def test_surface_cell_filter_current_counts_outgoing_to_vacuum(
     particle = particle_container[0]
     surface_crossing(particle_container, mcdc_struct, data)
     assert not particle["alive"]
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 2.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
 
 
 def test_surface_cell_filter_current_ignores_reflective_crossing(
@@ -124,10 +124,10 @@ def test_surface_cell_filter_current_ignores_reflective_crossing(
     particle = particle_container[0]
     surface_crossing(particle_container, mcdc_struct, data)
     assert particle["alive"]
-    assert np.isclose(particle["ux"], -0.5)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 0.0)
+    np.testing.assert_allclose(particle["ux"], -0.5, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
 
 
 def test_surface_cell_filter_current_scores_curved_boundary(
@@ -154,9 +154,9 @@ def test_surface_cell_filter_current_scores_curved_boundary(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 2.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
 
     # Outer -> inner across the same curved surface: incoming to c_inner (-)
     particle_container = crossing_particle(
@@ -167,9 +167,9 @@ def test_surface_cell_filter_current_scores_curved_boundary(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 2.0)
-    assert np.isclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(current_tally, mcdc_struct, data, 2), 2.0, rtol=1e-5, atol=1e-8)
 
 
 def test_surface_cell_filter_scores_only_selected_surface(
@@ -193,9 +193,9 @@ def test_surface_cell_filter_scores_only_selected_surface(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)
 
     particle_container = crossing_particle(
         slab_plane_x["s_mid"].ID,
@@ -205,6 +205,6 @@ def test_surface_cell_filter_scores_only_selected_surface(
     )
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 0), -2.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 1), 2.0)
-    assert np.isclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 0), -2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 1), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(_bin_value_score(tally, mcdc_struct, data, 2), 0.0, rtol=1e-5, atol=1e-8)

--- a/test/unit/tally/test_nonbounded_surface_tally.py
+++ b/test/unit/tally/test_nonbounded_surface_tally.py
@@ -49,7 +49,9 @@ def test_unbounded_surface_crossing_tally_scoring(
     particle["ux"] = ux
     surface_crossing(particle_container, mcdc_struct, data)
 
-    np.testing.assert_allclose(bin_value(unbounded_tally, mcdc_struct, data), expected, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        bin_value(unbounded_tally, mcdc_struct, data), expected, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_surface_crossing_tally_scores_vacuum_boundary(
@@ -70,7 +72,9 @@ def test_surface_crossing_tally_scores_vacuum_boundary(
     surface_crossing(particle_container, mcdc_struct, data)
 
     assert not particle["alive"]
-    np.testing.assert_allclose(bin_value(tally, mcdc_struct, data), 2.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        bin_value(tally, mcdc_struct, data), 2.0, rtol=1e-5, atol=1e-8
+    )
 
 
 def test_surface_crossing_tally_scores_after_reflective_boundary(
@@ -92,4 +96,6 @@ def test_surface_crossing_tally_scores_after_reflective_boundary(
 
     assert particle["alive"]
     np.testing.assert_allclose(particle["ux"], -0.5, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(bin_value(tally, mcdc_struct, data), 0.0, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        bin_value(tally, mcdc_struct, data), 0.0, rtol=1e-5, atol=1e-8
+    )

--- a/test/unit/tally/test_nonbounded_surface_tally.py
+++ b/test/unit/tally/test_nonbounded_surface_tally.py
@@ -49,7 +49,7 @@ def test_unbounded_surface_crossing_tally_scoring(
     particle["ux"] = ux
     surface_crossing(particle_container, mcdc_struct, data)
 
-    assert np.isclose(bin_value(unbounded_tally, mcdc_struct, data), expected)
+    np.testing.assert_allclose(bin_value(unbounded_tally, mcdc_struct, data), expected, rtol=1e-5, atol=1e-8)
 
 
 def test_surface_crossing_tally_scores_vacuum_boundary(
@@ -70,7 +70,7 @@ def test_surface_crossing_tally_scores_vacuum_boundary(
     surface_crossing(particle_container, mcdc_struct, data)
 
     assert not particle["alive"]
-    assert np.isclose(bin_value(tally, mcdc_struct, data), 2.0)
+    np.testing.assert_allclose(bin_value(tally, mcdc_struct, data), 2.0, rtol=1e-5, atol=1e-8)
 
 
 def test_surface_crossing_tally_scores_after_reflective_boundary(
@@ -91,5 +91,5 @@ def test_surface_crossing_tally_scores_after_reflective_boundary(
     surface_crossing(particle_container, mcdc_struct, data)
 
     assert particle["alive"]
-    assert np.isclose(particle["ux"], -0.5)
-    assert np.isclose(bin_value(tally, mcdc_struct, data), 0.0)
+    np.testing.assert_allclose(particle["ux"], -0.5, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(bin_value(tally, mcdc_struct, data), 0.0, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
## Summary

Bare `assert np.isclose(a, b)` silently fails with only `AssertionError` — no actual vs expected values, no diff, no magnitude. When a floating-point geometry test fails, the developer has to insert print statements or a debugger to find out what went wrong.

`np.testing.assert_allclose` is the standard fix: it prints the full array diff, the max absolute/relative difference, and which elements violated the tolerance.

### Changes

- Replaced all 121 occurrences of `assert np.isclose(...)` and `assert np.allclose(...)` across 10 unit-test files with `np.testing.assert_allclose(..., rtol=1e-5, atol=1e-8)`
- Tolerances match `np.isclose` defaults exactly — test sensitivity is unchanged
- All 120 unit tests pass

### Files touched

- `test/unit/geometry/surface/test_plane_{x,y,z}.py` (13 each)
- `test/unit/geometry/surface/test_torus{,_x,_y,_z}.py` (6–13 each)
- `test/unit/tally/test_cell_tally.py` (24)
- `test/unit/tally/test_cell_filter_interior_plane.py` (9)
- `test/unit/tally/test_nonbounded_surface_tally.py` (4)

Closes #414

Signed-off-by: Mike German <mike@stepsventures.com>