### PR TITLE
fix: 2D-vector setter writes nothing (`-` instead of `=`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 ### Fixed
 
+- Fix 2D-vector setter writes nothing (- instead of =) from [@steps-re]
+
 ### Security
 
 ## [0.14.1] - 2026-07-04

--- a/mcdc/code_factory/numba_objects_generator.py
+++ b/mcdc/code_factory/numba_objects_generator.py
@@ -1141,7 +1141,7 @@ def _accessor_2d_vector(object_name, attribute_name, stride, setter=False):
     text += f"    start = offset + index_1 * stride\n"
     text += f"    end = start + stride\n"
     if setter:
-        text += f"    data[start:end] - value\n\n\n"
+        text += f"    data[start:end] = value\n\n\n"
     else:
         text += f"    return data[start:end]\n\n\n"
     return text

--- a/mcdc/mcdc_set/multigroup_material.py
+++ b/mcdc/mcdc_set/multigroup_material.py
@@ -241,7 +241,7 @@ def mgxs_nu_d_vector(index_1, multigroup_material, data, value):
     stride = multigroup_material["J"]
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit
@@ -322,7 +322,7 @@ def mgxs_chi_s_vector(index_1, multigroup_material, data, value):
     stride = multigroup_material["G"]
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit
@@ -345,7 +345,7 @@ def mgxs_chi_p_vector(index_1, multigroup_material, data, value):
     stride = multigroup_material["G"]
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit
@@ -368,7 +368,7 @@ def mgxs_chi_d_vector(index_1, multigroup_material, data, value):
     stride = multigroup_material["G"]
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit

--- a/mcdc/mcdc_set/neutron_inelastic_scattering_reaction.py
+++ b/mcdc/mcdc_set/neutron_inelastic_scattering_reaction.py
@@ -38,7 +38,7 @@ def spectrum_probability_vector(index_1, neutron_inelastic_scattering_reaction, 
     stride = neutron_inelastic_scattering_reaction["N_spectrum"]
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit

--- a/mcdc/mcdc_set/source.py
+++ b/mcdc/mcdc_set/source.py
@@ -9,7 +9,7 @@ def move_velocities_vector(index_1, source, data, value):
     stride = 3
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit
@@ -90,7 +90,7 @@ def move_translations_vector(index_1, source, data, value):
     stride = 3
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit

--- a/mcdc/mcdc_set/surface.py
+++ b/mcdc/mcdc_set/surface.py
@@ -9,7 +9,7 @@ def move_velocities_vector(index_1, surface, data, value):
     stride = 3
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit
@@ -90,7 +90,7 @@ def move_translations_vector(index_1, surface, data, value):
     stride = 3
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit

--- a/mcdc/mcdc_set/table_data.py
+++ b/mcdc/mcdc_set/table_data.py
@@ -125,7 +125,7 @@ def aux_vector(index_1, table_data, data, value):
     stride = table_data["N"]
     start = offset + index_1 * stride
     end = start + stride
-    data[start:end] - value
+    data[start:end] = value
 
 
 @njit


### PR DESCRIPTION
`_accessor_2d_vector` in `mcdc/code_factory/numba_objects_generator.py` generates its setter with:

```python
text += f"    data[start:end] - value\n\n\n"
```

That emits `data[start:end] - value` — a subtraction whose result is thrown away — instead of `data[start:end] = value`. Every sibling accessor generator (`_accessor_1d`, `_accessor_2d`, `_accessor_3d_element`, ...) correctly emits `= value`, so this one is the odd one out and every generated `*_vector` setter silently writes nothing.

This fixes the generator template and the checked-in generated modules where the broken setter already landed:
- `mcdc/mcdc_set/table_data.py`
- `mcdc/mcdc_set/multigroup_material.py` (4 setters)
- `mcdc/mcdc_set/source.py` (2)
- `mcdc/mcdc_set/neutron_inelastic_scattering_reaction.py`
- `mcdc/mcdc_set/surface.py` (2)

If those modules are meant to be regenerated from the template rather than hand-edited, let me know and I'll drop the generated-file changes and keep only the template fix.