### PR TITLE
Release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 ### Changed
 
-- Add explicit upper bounds for all build, runtime, documentation, and development dependencies, from [@ilhamv]
 - Hide flyout in Read the Docs, from [@ilhamv]
+
+### Fixed
+
+- Prevent unbounded dependency resolution from selecting incompatible releases that break MC/DC by adding explicit upper bounds for all build, runtime, documentation, and development dependencies, from [@ilhamv]
 
 ## [0.15.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.1] - 2026-08-12
 
 ### Added
 
@@ -16,14 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 - Add explicit upper bounds for all build, runtime, documentation, and development dependencies, from [@ilhamv]
 - Hide flyout in Read the Docs, from [@ilhamv]
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 
 ## [0.15.0] - 2026-08-11
 
@@ -158,7 +150,7 @@ The pre-refactor implementation remains available in the `cement` branch as a re
 
 - Multi-table distribution table selection sampling from [@melekderman]
 
-[Unreleased]: https://github.com/mcdc-project/mcdc/tree/dev
+[0.15.1]: https://github.com/mcdc-project/mcdc/releases/tag/v0.15.1
 [0.15.0]: https://github.com/mcdc-project/mcdc/releases/tag/v0.15.0
 [0.14.2]: https://github.com/mcdc-project/mcdc/releases/tag/v0.14.2
 [0.14.1]: https://github.com/mcdc-project/mcdc/releases/tag/v0.14.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,8 +34,8 @@ keywords:
   - Numba
   - GPU
 license: BSD-3-Clause
-version: 0.15.0
-date-released: '2026-08-11'
+version: 0.15.1
+date-released: '2026-08-12'
 preferred-citation:
   type: article
   authors:

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -5,7 +5,7 @@
     "url": "https://mcdc.readthedocs.io/en/dev/"
   },
   {
-    "name": "0.15 (stable)",
+    "name": "0.15.1 (stable)",
     "version": "stable",
     "url": "https://mcdc.readthedocs.io/en/stable/",
     "preferred": true

--- a/docs/source/developer_guide/release_policy.rst
+++ b/docs/source/developer_guide/release_policy.rst
@@ -21,6 +21,9 @@ Patch Releases
 
 Bug fixes are not held until the next seasonal minor release.
 Once a fix has passed review and the relevant validation and release checks, MC/DC publishes a patch release as soon as practical.
+Every patch release must include a non-empty ``Fixed`` section in ``CHANGELOG.md`` that describes the user-visible defect corrected by the release.
+Supporting changes may also appear under other headings, but the defect that justifies the patch release must be stated under ``Fixed``.
+For dependency-compatibility patches, identify the installation or runtime failure prevented and the affected dependency or version range when known.
 
 Published versions and release notes are available from the `MC/DC releases page <https://github.com/mcdc-project/mcdc/releases>`_.
 
@@ -38,6 +41,7 @@ Prepare the Release
 #. Confirm the intended version and scope against the release policy above.
 #. Review the ``Unreleased`` section of ``CHANGELOG.md``.
    Ensure every user-visible change is included under the correct heading, remove empty headings, and add contributor attribution where appropriate.
+   For a patch release, confirm that ``Fixed`` is non-empty and clearly states the defect that justifies the release.
 #. Finalize the release version and date in ``CHANGELOG.md`` and ``CITATION.cff``, and update the stable entry's display name in ``docs/source/_static/switcher.json`` to the full ``X.Y.Z (stable)`` version while retaining ``stable`` as its version identifier and URL.
 #. Confirm that documentation, examples, deprecation notices, and migration guidance match the release behavior.
 #. Verify the supported Python versions in ``pyproject.toml``, continuous integration, and the user documentation agree.


### PR DESCRIPTION
This patch prevents unbounded dependency resolution from selecting incompatible releases that break MC/DC by adding explicit upper bounds for all build, runtime, documentation, and development dependencies.