### PR TITLE
Refresh CHANGELOG and display older documentation versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 ### Changed
 
+- Show previously published documentation versions in the documentation version switcher, from [@ilhamv]
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.15.1] - 2026-08-12
 
 ### Added
@@ -153,6 +167,7 @@ The pre-refactor implementation remains available in the `cement` branch as a re
 
 - Multi-table distribution table selection sampling from [@melekderman]
 
+[Unreleased]: https://github.com/mcdc-project/mcdc/tree/dev
 [0.15.1]: https://github.com/mcdc-project/mcdc/releases/tag/v0.15.1
 [0.15.0]: https://github.com/mcdc-project/mcdc/releases/tag/v0.15.0
 [0.14.2]: https://github.com/mcdc-project/mcdc/releases/tag/v0.14.2

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -9,5 +9,15 @@
     "version": "stable",
     "url": "https://mcdc.readthedocs.io/en/stable/",
     "preferred": true
+  },
+  {
+    "name": "0.15.0",
+    "version": "v0.15.0",
+    "url": "https://mcdc.readthedocs.io/en/v0.15.0/"
+  },
+  {
+    "name": "0.14.2",
+    "version": "v0.14.2",
+    "url": "https://mcdc.readthedocs.io/en/v0.14.2/"
   }
 ]

--- a/docs/source/developer_guide/release_policy.rst
+++ b/docs/source/developer_guide/release_policy.rst
@@ -42,7 +42,12 @@ Prepare the Release
 #. Review the ``Unreleased`` section of ``CHANGELOG.md``.
    Ensure every user-visible change is included under the correct heading, remove empty headings, and add contributor attribution where appropriate.
    For a patch release, confirm that ``Fixed`` is non-empty and clearly states the defect that justifies the release.
-#. Finalize the release version and date in ``CHANGELOG.md`` and ``CITATION.cff``, and update the stable entry's display name in ``docs/source/_static/switcher.json`` to the full ``X.Y.Z (stable)`` version while retaining ``stable`` as its version identifier and URL.
+#. Finalize the release version and date in ``CHANGELOG.md`` and ``CITATION.cff``.
+#. Update ``docs/source/_static/switcher.json``:
+
+   - Change the stable entry's display name to the full ``X.Y.Z (stable)`` version while retaining ``stable`` as its version identifier and URL.
+   - Add the previous stable release as a historical entry, using its Read the Docs tag identifier and URL, and retain the existing historical entries in newest-to-oldest order.
+   - Confirm that every listed historical version is active, built, and reachable on Read the Docs.
 #. Confirm that documentation, examples, deprecation notices, and migration guidance match the release behavior.
 #. Verify the supported Python versions in ``pyproject.toml``, continuous integration, and the user documentation agree.
 


### PR DESCRIPTION
Refresh CHANGELOG for the next release cycle and display older documentation versions.