### PR TITLE
Fix array size literal and overload targeting for CUDA interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 ### Deprecated
 
 ### Removed
+- Caching of the `souce_loop` function is removed for GPU execution, from [@braxtoncuneo].
 
 ### Fixed
 

--- a/mcdc/code_factory/gpu/program_builder.py
+++ b/mcdc/code_factory/gpu/program_builder.py
@@ -157,7 +157,11 @@ def forward_declare_gpu_program(simulation_dtype):
 
     from mcdc.transport import util
 
-    @nb.extending.overload(util.access_simulation, target="hip")
+    if config.ROCM_AVAILABLE:
+        access_target="hip"
+    else:
+        access_target="gpu"
+    @nb.extending.overload(util.access_simulation, target=access_target)
     def access_simulation_gpu_overload(program):
         def impl(program):
             return access_simulation(program)

--- a/mcdc/code_factory/gpu/program_builder.py
+++ b/mcdc/code_factory/gpu/program_builder.py
@@ -158,9 +158,10 @@ def forward_declare_gpu_program(simulation_dtype):
     from mcdc.transport import util
 
     if config.ROCM_AVAILABLE:
-        access_target="hip"
+        access_target = "hip"
     else:
-        access_target="gpu"
+        access_target = "gpu"
+
     @nb.extending.overload(util.access_simulation, target=access_target)
     def access_simulation_gpu_overload(program):
         def impl(program):

--- a/mcdc/code_factory/gpu/transport/simulation.py
+++ b/mcdc/code_factory/gpu/transport/simulation.py
@@ -14,7 +14,7 @@ from mcdc.transport.simulation import source_closeout
 caching = config.caching
 
 
-@njit(cache=caching)
+@njit(cache=False)
 def source_loop(seed, simulation, data):
     # For async execution
     iter_count = 655360000

--- a/mcdc/code_factory/numba_layers_generator.py
+++ b/mcdc/code_factory/numba_layers_generator.py
@@ -351,7 +351,7 @@ def generate_numba_layers(simulation):
     # ==================================================================================
 
     if config.target == "gpu":
-        gpu_builder.prepare_gpu_program(simulation_dtype, data["size"])
+        gpu_builder.prepare_gpu_program(simulation_dtype, int(data["size"]))
 
     # ==================================================================================
     # Allocate the flattened data and re-set the objects


### PR DESCRIPTION
## Summary of changes
This PR:
- adds fixes to account for discrepancies between how `numba-hip` and `numba-cuda` handle literals and targeting
- removes caching from the gpu source loop definition to avoid breakage from switching between `--gpu_strategy=event` and `--gpu_strategy=async`.
- allows for gpu execution on CUDA platforms, in addition to AMD platforms.

## Types of changes

- Bug fix: The target for the `access_simulation` overload used for gpu now switches between `"hip"` and `"gpu"` depending upon whether the current platform is AMD- or NVIDIA-based. `numba-hip` counts itself as a different target for overloads, so it cannot simply be targeted through `"gpu"`, based on testing and a review of the error-throwing code.
- Bug fix: The data size passed to `prepare_gpu_program` is explicitly cast to a normal Python int before being passed as an argument. Depending upon whether or not compilation happens via `numba-hip` or `numba-cuda`, the type of the uncast expression can be either `numba.int64` or `numpy.int64`, which cannot be handled in the same way. Forcing the type to be a conventional `int` removes this difference.
- Bug fix: the `source_loop` definition used for gpu execution is no longer cached, since the Numba caching currently does not detect a change between `--gpu_strategy=event` and `--gpu_strategy=async`.

## Developer Checklist

- [x] I have read the [contributing guide](https://mcdc.readthedocs.io/en/dev/contributing/index.html).
- [x] My code follows the [code style](https://mcdc.readthedocs.io/en/dev/contributing/index.html#code-styling) of this project.
- [x] I have updated `CHANGELOG.md` as needed. <!-- Delete if not applicable -->
- [ ] All new and existing tests pass

## Associated Issues and PRs
- related to #479 and #440 

## Associated Developers
- @ilhamv 
