### PR TITLE
optimize tally moments storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 
 - Update GPU transport support for the current MC/DC data model and Harmonize runtime, including GPU-compatible state access, particle-bank operations, array accessors, and torus intersections, from [@braxtoncuneo].
 - Show previously published documentation versions in the documentation version switcher, from [@ilhamv]
+- Optimize tally moments memory allocation — only allocate to non-master rank if necessary, from [@ilhamv]
 
 ### Deprecated
 

--- a/mcdc/code_factory/numba_layers_generator.py
+++ b/mcdc/code_factory/numba_layers_generator.py
@@ -115,7 +115,21 @@ def generate_numba_layers(simulation):
     annotations = {}
     structures = {}
     records = {}
-    data = {"size": 0}
+    # Per-history statistics are accumulated locally; batch/cycle statistics
+    # are accumulated only after reduction to master. Preserve GPU layouts
+    # because all ranks load the same compiled GPU program.
+    settings = simulation.settings
+    local_moments = (
+        not settings.neutron_eigenvalue_mode
+        and settings.N_batch == 1
+        and not settings.use_census_based_tally
+    )
+    data = {
+        "size": 0,
+        "store_tally_moments": (
+            config.target == "gpu" or simulation.mpi_master or local_moments
+        ),
+    }
     accessor_targets = {}
 
     for mcdc_class in mcdc_classes:
@@ -734,13 +748,14 @@ def set_object(
     # Set tally bins
     if class_ == Tally:
         tally_size = np.prod(object_.bin_shape)
+        moment_size = tally_size if data.get("store_tally_moments", True) else 0
         record[f"bin_offset"] = data["size"]
         record[f"bin_sum_offset"] = data["size"] + tally_size
-        record[f"bin_sum_square_offset"] = data["size"] + tally_size * 2
+        record[f"bin_sum_square_offset"] = data["size"] + tally_size + moment_size
         record[f"bin_length"] = tally_size
-        record[f"bin_sum_length"] = tally_size
-        record[f"bin_sum_square_length"] = tally_size
-        data["size"] += 3 * tally_size
+        record[f"bin_sum_length"] = moment_size
+        record[f"bin_sum_square_length"] = moment_size
+        data["size"] += tally_size + 2 * moment_size
 
     # Check structure-record compatibility
     missing = set([x[0] for x in structure]) - set(record.keys())

--- a/mcdc/transport/simulation.py
+++ b/mcdc/transport/simulation.py
@@ -81,7 +81,7 @@ def fixed_source_simulation(simulation_container, data):
                 if simulation["mpi_master"]:
                     with objmode():
                         output_module.generate_census_based_tally(simulation, data)
-                tally_module.closeout.reset_sum_bins(simulation, data)
+                    tally_module.closeout.reset_sum_bins(simulation, data)
 
             # Terminate census loop if all banks are empty
             if (

--- a/mcdc/transport/tally/closeout.py
+++ b/mcdc/transport/tally/closeout.py
@@ -43,10 +43,12 @@ def _reduce(tally, simulation, data):
         data[start + i] /= N_particle
 
     # MPI Reduce
-    buff = np.zeros(N)
+    master = simulation["mpi_master"]
     with objmode():
-        MPI.COMM_WORLD.Reduce(data[start:end], buff, MPI.SUM, 0)
-    data[start:end] = buff
+        if master:
+            MPI.COMM_WORLD.Reduce(MPI.IN_PLACE, data[start:end], MPI.SUM, 0)
+        else:
+            MPI.COMM_WORLD.Reduce(data[start:end], None, MPI.SUM, 0)
 
 
 # ======================================================================================
@@ -56,8 +58,20 @@ def _reduce(tally, simulation, data):
 
 @njit
 def accumulate(simulation, data):
+    settings = simulation["settings"]
+    local_moments = (
+        not settings["neutron_eigenvalue_mode"]
+        and settings["N_batch"] == 1
+        and not settings["use_census_based_tally"]
+    )
     for tally in simulation["tallies"]:
-        _accumulate(tally, data)
+        if simulation["mpi_master"] or local_moments:
+            _accumulate(tally, data)
+
+        # Reset score bin
+        start = tally["bin_offset"]
+        for i in range(tally["bin_length"]):
+            data[start + i] = 0.0
 
 
 @njit
@@ -67,7 +81,7 @@ def _accumulate(tally, data):
     offset_sum = tally["bin_sum_offset"]
     offset_sum_square = tally["bin_sum_square_offset"]
 
-    # Note: Three separate loops are employed to avoid cache miss due to potentially
+    # Note: Separate loops are employed to avoid cache miss due to potentially
     #       large N_bin
 
     # Sum of score
@@ -79,10 +93,6 @@ def _accumulate(tally, data):
     for i in range(N_bin):
         score = data[offset_bin + i]
         data[offset_sum_square + i] += score * score
-
-    # Reset score bin
-    for i in range(N_bin):
-        data[offset_bin + i] = 0.0
 
 
 # ======================================================================================
@@ -114,13 +124,20 @@ def _finalize(tally, simulation, data):
 
     else:
         # MPI Reduce
-        buff = np.zeros(N_bin)
-        buff_sq = np.zeros(N_bin)
+        master = simulation["mpi_master"]
         with objmode():
-            MPI.COMM_WORLD.Reduce(data[sum_start:sum_end], buff, MPI.SUM, 0)
-            MPI.COMM_WORLD.Reduce(data[sum_sq_start:sum_sq_end], buff_sq, MPI.SUM, 0)
-        data[sum_start:sum_end] = buff
-        data[sum_sq_start:sum_sq_end] = buff_sq
+            if master:
+                MPI.COMM_WORLD.Reduce(MPI.IN_PLACE, data[sum_start:sum_end], MPI.SUM, 0)
+                MPI.COMM_WORLD.Reduce(
+                    MPI.IN_PLACE, data[sum_sq_start:sum_sq_end], MPI.SUM, 0
+                )
+            else:
+                MPI.COMM_WORLD.Reduce(data[sum_start:sum_end], None, MPI.SUM, 0)
+                MPI.COMM_WORLD.Reduce(data[sum_sq_start:sum_sq_end], None, MPI.SUM, 0)
+
+    # All ranks must finish any reductions before workers can return.
+    if not simulation["mpi_master"]:
+        return
 
     # Calculate and store statistics
     #   sum --> mean


### PR DESCRIPTION
## Summary of changes
<!--
    In at least one sentence, describe the PR you are submitting.
-->

This PR optimizes tally storage by only allocating tally moments to the master rank. The tally moments are still allocated to the non-master rank if we run a one-batch simulation only.

## Types of changes
<!---
    What types of changes does your code introduce?
-->

- Optimization

## Developer Checklist
<!--
    Please review the following checklist and ensure you have addressed each applicable item.
    Put an `x` in all boxes once completed.
-->

- [x] I have read the [contributing guide](https://mcdc.readthedocs.io/en/dev/contributing/index.html).
- [x] My code follows the [code style](https://mcdc.readthedocs.io/en/dev/contributing/index.html#code-styling) of this project.
- [x] I have updated the documentation as needed. <!-- Delete if not applicable -->
- [x] I have updated `CHANGELOG.md` as needed. <!-- Delete if not applicable -->
- [x] I have added or updated tests to cover my changes. <!-- Delete if not applicable -->
- [x] All new and existing tests pass

## Associated Issues and PRs
<!--
    Please note any issues or pull requests associated with this pull request using GitHub keywords. 
    For multiple linked issues, repeat the keyword for each issue.
-->

- closes #
- related to #

## Associated Developers
<!--
    Please mention any developers who should be alerted of this PR.
-->

- @
