### PR TITLE
Support named NumPy NDArray aliases

### DIFF
--- a/mcdc/code_factory/numba_layers_generator.py
+++ b/mcdc/code_factory/numba_layers_generator.py
@@ -23,7 +23,7 @@ from mcdc.object_.base import (
 )
 from mcdc.object_.particle import Particle, ParticleBank, ParticleData
 from mcdc.object_.tally import Tally
-from mcdc.object_.util import parse_dimension_expression
+from mcdc.object_.util import normalize_ndarray_hint, parse_dimension_expression
 from mcdc.print_ import print_error
 from mcdc.util import flatten
 
@@ -473,7 +473,7 @@ def set_structure(
     accessor_target = accessor_targets[label]
 
     for field in annotation:
-        hint = annotation[field]
+        hint = normalize_ndarray_hint(annotation[field])
         hint_origin = get_origin(hint)
         hint_args = get_args(hint)
         embedded_mcdc_base = is_embedded_mcdc_base(hint)
@@ -1014,6 +1014,7 @@ def parse_annotations_dict(ann: dict[str, str]) -> dict[str, object]:
 
 def decode_annotated_ndarray(hint):
     inner, metadata = get_args(hint)
+    inner = normalize_ndarray_hint(inner)
     inner_origin = get_origin(inner)
     inner_args = get_args(inner)
     shape_type, dtype_type = inner_args
@@ -1026,6 +1027,7 @@ def decode_annotated_ndarray(hint):
 
 
 def get_ndarray_dtype(hint):
+    hint = normalize_ndarray_hint(hint)
     hint_args = get_args(hint)
     if len(hint_args) < 2:
         return None

--- a/mcdc/object_/util.py
+++ b/mcdc/object_/util.py
@@ -1,5 +1,5 @@
 import re
-from typing import Annotated, Union, get_args, get_origin
+from typing import Annotated, Any, Union, get_args, get_origin
 
 import numpy as np
 from numpy import float64
@@ -35,6 +35,15 @@ def parse_dimension_expression(expression: str) -> tuple[str, int]:
             offset *= -1
 
     return attribute, offset
+
+
+def normalize_ndarray_hint(hint):
+    """Expand NumPy's named NDArray alias to the ndarray shape/dtype form."""
+    if get_origin(hint) is NDArray:
+        # Named aliases expose only the scalar argument, not shape and dtype.
+        (scalar_type,) = get_args(hint)
+        return np.ndarray[tuple[Any, ...], np.dtype[scalar_type]]
+    return hint
 
 
 def check_type(value, hint, cls, obj=None) -> bool:
@@ -85,6 +94,7 @@ def check_type(value, hint, cls, obj=None) -> bool:
         return _mro_name_matches(value, hint)
 
     # Check structured typing annotations
+    hint = normalize_ndarray_hint(hint)
     origin = get_origin(hint)
 
     if origin is Annotated:


### PR DESCRIPTION
Normalize named NDArray[scalar] aliases before decoding array annotations, preserving compatibility with the expanded numpy.ndarray[shape, dtype] form. This fixes annotation unpacking failures and recognition of unannotated array fields for certain Python versions.